### PR TITLE
Add JSON output for broken links and improve concurrency safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ with:
 > - `files: "README.md,CONTRIBUTING.md"`
 > - `files: "README.md, CONTRIBUTING.md docs/guide.md"`
 
+## Outputs
+
+| Output        | Description                                                            | Required | Default |
+| ------------- | ---------------------------------------------------------------------- | -------- | ------- |
+| `json`        | JSON output of broken links. Example: `[{"link":"https://example.com/broken.html","file":"README.md","line_num":5}]`. This will be an empty list if no links are broken. | No       | `.`     |
+
 ## Configuration File
 
 You can use a configuration file to set options for the link checker. Create a file (e.g., `.linkcheck.conf`) with the following format:

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,9 @@ inputs:
   config-file:
     description: "Path to configuration file"
     required: false
+outputs:
+  json:
+    description: "JSON output of broken links. Example: `[{"link":"https://example.com/broken.html","file":"README.md","line_num":5}]`. This will be an empty list if no links are broken."
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
     required: false
 outputs:
   json:
-    description: "JSON output of broken links. Example: `[{"link":"https://example.com/broken.html","file":"README.md","line_num":5}]`. This will be an empty list if no links are broken."
+    description: 'JSON output of broken links. Example: `[{"link":"https://example.com/broken.html","file":"README.md","line_num":5}]`. This will be an empty list if no links are broken.'
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/check-links.sh
+++ b/check-links.sh
@@ -275,7 +275,7 @@ fi
 
 # Echo the JSON list of broken links to the GitHub output
 if [ -n "$GITHUB_OUTPUT" ]; then
-    echo "json=$(cat "$FILE_LIST")" >> "$GITHUB_OUTPUT"
+    echo "json=$(cat "$FILE_LIST" | jq -c .)" >> "$GITHUB_OUTPUT"
 fi
 
 # Print summary

--- a/check-links.sh
+++ b/check-links.sh
@@ -253,7 +253,8 @@ if [ -n "$EXCLUDE" ]; then
     done
 fi
 
-FILE_LIST=/tmp/file_list.json
+FILE_LIST=$(mktemp /tmp/file_list.XXXXXX.json)
+trap 'rm -f "$FILE_LIST"' EXIT
 echo '[]' > "$FILE_LIST"
 
 # Get list of files to check


### PR DESCRIPTION
- This will add a `json` output with any broken links, which will either be an empty list (`[]`) if there are no broken links, or it will look like this if there are broken links:
```
[
  {
    "link": "https://example.com/broken.html",
    "file": "README.md",
    "line_num": 5
  }
]
```
- The reason why a JSON output is useful is because it can then be passed to other steps which can act on the output. For example, a [workflow like this](https://github.com/jwr0/markdown-link-checker/blob/main/.github/workflows/example.yml) could check for broken links and then [leave PR comments like this](https://github.com/jwr0/markdown-link-checker/pull/1#discussion_r2314602090).
- Note that I added a few troubleshooting commits as I was testing this. You'll probably want to squash these if/when merging.
- Thanks for reviewing this PR. I'm open to suggestions and changes. And thanks for all your efforts on this tool.